### PR TITLE
Add support for CompleteStr and CompleteByteSlice

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,6 +257,18 @@ impl From<&str> for Input {
   }
 }
 
+impl From<nom::types::CompleteByteSlice<'_>> for Input {
+  fn from(input: nom::types::CompleteByteSlice) -> Self {
+    Input::Bytes(input.as_ptr(), input.len())
+  }
+}
+
+impl From<nom::types::CompleteStr<'_>> for Input {
+  fn from(input: nom::types::CompleteStr) -> Self {
+    Input::String(input.as_ptr(), input.len())
+  }
+}
+
 impl Debug for Input {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     match self {
@@ -516,6 +528,7 @@ macro_rules! tr (
 mod tests {
   use super::*;
   use nom::digit;
+  use nom::types::CompleteStr;
 
   declare_trace!();
 
@@ -560,6 +573,16 @@ mod tests {
     deactivate_trace!();
     activate_trace!();
     println!("parsed: {:?}", parser("data: (1,2,3)"));
+
+    print_trace!();
+    reset_trace!();
+  }
+
+  #[test]
+  pub fn complete_str_parser() {
+    named!(parser<CompleteStr, CompleteStr>, tr!(tag!("a")));
+
+    assert_eq!(parser(CompleteStr("abc")), Ok((CompleteStr("bc"), CompleteStr("a"))));
 
     print_trace!();
     reset_trace!();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,9 @@
 //!
 //! ```rust
 //! #[macro_use] extern crate nom;
-//! #[macro_use] extern crate nom-trace;
+//! #[macro_use] extern crate nom_trace;
+//!
+//! use nom::digit;
 //!
 //! //adds a thread local storage object to store the trace
 //! declare_trace!();
@@ -40,7 +42,7 @@
 //! ```
 //!
 //! You would get the following result
-//! ```
+//! ```ignore
 //! parsed: Ok(("", ["1", "2", "3"]))
 //! preceded        "data: (1,2,3)"
 //!
@@ -537,7 +539,6 @@ mod tests {
 
     print_trace!();
     reset_trace!();
-    panic!();
   }
 
   #[test]
@@ -562,6 +563,5 @@ mod tests {
 
     print_trace!();
     reset_trace!();
-    panic!();
   }
 }


### PR DESCRIPTION
Previously trying to trace with a `CompleteStr` or `CompleteByteSlice` would fail because they could not convert to `Input`.  I implemented `From<CompleteStr>` and `From<CompleteByteSlice>` for `Input` and added a test. I also fixed the other tests and doc-tests.